### PR TITLE
convert strings to UTF-8 before generating YAML

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,10 @@ build
 Session.vim
 yaml_*.tar.gz
 .Renv-version
+*.Rproj
 *.o
 *.so
+*.dll
+.Rproj.user
+.Rbuildignore
+.Rhistory

--- a/R/as.yaml.R
+++ b/R/as.yaml.R
@@ -3,10 +3,11 @@ function(x, line.sep = c('\n', '\r\n', '\r'), indent = 2, omap = FALSE,
          column.major = TRUE, unicode = TRUE, precision = getOption('digits'),
          indent.mapping.sequence = FALSE, handlers = NULL) {
 
+  x <- as.utf8(x)
   line.sep <- match.arg(line.sep)
   res <- .Call(C_serialize_to_yaml, x, line.sep, indent, omap, column.major,
                unicode, precision, indent.mapping.sequence, handlers,
-               PACKAGE="yaml")
+               PACKAGE = "yaml")
   Encoding(res) <- "UTF-8"
   res
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,0 +1,12 @@
+`as.utf8` <-
+function(x) {
+  
+  if (is.character(x)) {
+    enc2utf8(x)
+  } else if (is.list(x)) {
+    lapply(x, as.utf8)
+  } else {
+    x
+  }
+  
+}

--- a/inst/tests/test_as_yaml.R
+++ b/inst/tests/test_as_yaml.R
@@ -440,3 +440,9 @@ test_custom_tag_for_unnamed_list <- function() {
   result <- as.yaml(x)
   checkEquals(expected, result)
 }
+
+test_latin1_strings <- function() {
+  data <- list(description = enc2native("á"))
+  result <- as.yaml(data)
+  checkEquals(result, enc2utf8("description: á\n"))
+}


### PR DESCRIPTION
This fixes a crash on Windows where attempts to convert latin1 strings could cause a crash.