### PR TITLE
Suppress warning about incomplete last line

### DIFF
--- a/R/read_yaml.R
+++ b/R/read_yaml.R
@@ -33,6 +33,10 @@ function(file, fileEncoding = "UTF-8", text, error.label, ...) {
     stop("'file' must be a character string or connection")
   }
 
-  string <- paste(readLines(file), collapse="\n")
+  # Suppress warning about incomplete last line.
+  # Also suppresses warning about embedded nul.
+  # See r-lib/pkgdown issue #1419.
+
+  string <- paste(readLines(file, warn = FALSE), collapse="\n")
   yaml.load(string, error.label = error.label, ...)
 }

--- a/inst/CHANGELOG
+++ b/inst/CHANGELOG
@@ -1,3 +1,6 @@
+v2.2.1.99
+  - suppress warning if .yaml file does not end in LF.
+
 v2.2.1
   - add merge.precedence option to yaml.load
   - fix improper handling of explicit '!bool' tag (reported by Luke Goodsell)


### PR DESCRIPTION
This suppresses the warning from `readLines()` about an incomplete last line.  It will also suppress warnings about embedded nuls.  It's motivated by https://github.com/r-lib/pkgdown/issues/1419 , which was caused by reading a non-YAML file, looking for YAML:  so I'm not certain you'll want to suppress this.