### PR TITLE
Encoding to UTF-8 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,10 @@ build
 Session.vim
 yaml_*.tar.gz
 .Renv-version
+*.Rproj
 *.o
 *.so
+*.dll
+.Rproj.user
+.Rbuildignore
+.Rhistory

--- a/Makefile
+++ b/Makefile
@@ -35,6 +35,7 @@ SRCS = src/yaml_private.h \
 	LICENSE \
 	R/yaml.load.R \
 	R/zzz.R \
+	R/utils.R \
 	R/yaml.load_file.R \
 	R/as.yaml.R \
 	R/read_yaml.R \
@@ -77,6 +78,7 @@ BUILD_SRCS = build/yaml/src/yaml_private.h \
 	build/yaml/LICENSE \
 	build/yaml/R/yaml.load.R \
 	build/yaml/R/zzz.R \
+	build/yaml/R/utils.R \
 	build/yaml/R/yaml.load_file.R \
 	build/yaml/R/as.yaml.R \
 	build/yaml/R/read_yaml.R \

--- a/R/as.yaml.R
+++ b/R/as.yaml.R
@@ -3,10 +3,11 @@ function(x, line.sep = c('\n', '\r\n', '\r'), indent = 2, omap = FALSE,
          column.major = TRUE, unicode = TRUE, precision = getOption('digits'),
          indent.mapping.sequence = FALSE, handlers = NULL) {
 
+  x <- as.utf8(x)
   line.sep <- match.arg(line.sep)
   res <- .Call(C_serialize_to_yaml, x, line.sep, indent, omap, column.major,
                unicode, precision, indent.mapping.sequence, handlers,
-               PACKAGE="yaml")
+               PACKAGE = "yaml")
   Encoding(res) <- "UTF-8"
   res
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,0 +1,12 @@
+`as.utf8` <-
+function(x) {
+  
+  if (is.character(x)) {
+    enc2utf8(x)
+  } else if (is.list(x)) {
+    lapply(x, as.utf8)
+  } else {
+    x
+  }
+  
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,12 +1,14 @@
 `as.utf8` <-
 function(x) {
-  
   if (is.character(x)) {
-    enc2utf8(x)
+    coded <- enc2utf8(x)
+    attributes(coded) <- attributes(x)
+    coded
   } else if (is.list(x)) {
-    lapply(x, as.utf8)
+    coded <- lapply(x, as.utf8)
+    attributes(coded) <- attributes(x)
+    coded
   } else {
     x
   }
-  
 }

--- a/inst/tests/test_as_yaml.R
+++ b/inst/tests/test_as_yaml.R
@@ -444,5 +444,12 @@ test_custom_tag_for_unnamed_list <- function() {
 test_latin1_strings <- function() {
   data <- list(description = enc2native("á"))
   result <- as.yaml(data)
-  checkEquals(result, enc2utf8("description: á\n"))
+  checkEquals(result, "description: á\n")
 }
+
+test_unknown_strings <- function() {
+  data <- list(x="\x9b")
+  result <- as.yaml(data)
+  checkEquals(result, "x: <9b>\n")
+}
+

--- a/inst/tests/test_as_yaml.R
+++ b/inst/tests/test_as_yaml.R
@@ -440,3 +440,9 @@ test_custom_tag_for_unnamed_list <- function() {
   result <- as.yaml(x)
   checkEquals(expected, result)
 }
+
+test_latin1_strings <- function() {
+  data <- list(description = enc2native("á"))
+  result <- as.yaml(data)
+  checkEquals(result, enc2utf8("description: á\n"))
+}


### PR DESCRIPTION
A modified version of 7256cba34fa2aa0607fed6abbfa5e0dcffb8e4d1 that preserves attributes and passes tests. This should solve #90 and #105.