### PR TITLE
Add quote support for strings, addresses #72

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,6 +358,19 @@ as.yaml(c(TRUE, FALSE), handlers = list(
 ))
 ```
 
+##### Quoted Strings
+
+There are times you might need to ensure a string scalar is quoted.  Apply a
+non-null attribute of "quoted" to the string you need quoted and it will come
+out with double quotes around it.
+
+```r
+port_def <- "80:80"
+attr(port_def, "quoted") <- TRUE
+x <- list(ports = list(port_def))
+as.yaml(x)
+```
+
 ##### Custom tags
 
 You can specify YAML tags for R objects by setting the `'tag'` attribute

--- a/inst/tests/test_as_yaml.R
+++ b/inst/tests/test_as_yaml.R
@@ -440,3 +440,11 @@ test_custom_tag_for_unnamed_list <- function() {
   result <- as.yaml(x)
   checkEquals(expected, result)
 }
+
+test_quotes_for_string <- function() {
+  port_def <- "80:80"
+  attr(port_def, "quoted") <- TRUE
+  x <- list(ports = list(port_def))
+  result <- as.yaml(x)
+  checkEquals(expected, result)
+}

--- a/man/as.yaml.Rd
+++ b/man/as.yaml.Rd
@@ -43,6 +43,9 @@
   document, but you can emit strings that would otherwise be quoted.  This is
   useful for changing how logical vectors are emitted (see below for example).
 
+  Character vectors that have an attribute of \sQuote{quoted} will be wrapped
+  in double quotes (see below for example).
+
   You can specify YAML tags for R objects by setting the \sQuote{tag} attribute
   to a character vector of length 1.  If you set a tag for a vector, the tag
   will be applied to the YAML sequence as a whole, unless the vector has only 1
@@ -91,6 +94,12 @@
       return(result)
     }
   ))
+
+  # force quotes around a string
+  port_def <- "80:80"
+  attr(port_def, "quoted") <- TRUE
+  x <- list(ports = list(port_def))
+  as.yaml(x)
 
   # custom tag for scalar
   x <- "thing"

--- a/src/r_ext.c
+++ b/src/r_ext.c
@@ -2,6 +2,7 @@
 
 SEXP Ryaml_KeysSymbol = NULL;
 SEXP Ryaml_TagSymbol = NULL;
+SEXP Ryaml_QuotedSymbol = NULL;
 SEXP Ryaml_IdenticalFunc = NULL;
 SEXP Ryaml_FormatFunc = NULL;
 SEXP Ryaml_PasteFunc = NULL;
@@ -243,6 +244,7 @@ R_CallMethodDef callMethods[] = {
 void R_init_yaml(DllInfo *dll) {
   Ryaml_KeysSymbol = install("keys");
   Ryaml_TagSymbol = install("tag");
+  Ryaml_QuotedSymbol = install("quoted");
   Ryaml_CollapseSymbol = install("collapse");
   Ryaml_IdenticalFunc = findFun(install("identical"), R_GlobalEnv);
   Ryaml_FormatFunc = findFun(install("format"), R_GlobalEnv);


### PR DESCRIPTION
Partially addresses #72, at least enough for what I need.

If a string needs to have quotes around it, you can indicate that like so:

```r
port_def <- "80:80"
attr(port_def, "quoted") <- TRUE
x <- list(ports = list(port_def))
as.yaml(x)
```